### PR TITLE
Bug fixes; updated the esmdecoder to fix the batching issue

### DIFF
--- a/raygun/commands/train.py
+++ b/raygun/commands/train.py
@@ -6,7 +6,7 @@ from raygun.modelv2.raygun import Raygun
 from raygun.modelv2.esmdecoder import DecoderBlock
 from raygun.modelv2.loader import RaygunData
 from raygun.modelv2.ltraygun import RaygunLightning
-from raygun.pretrained import raygun_2_2mil_800M
+from raygun.pretrained import raygun_4_4mil_800M
 import yaml
 from torch.utils.data import DataLoader
 from tqdm import tqdm
@@ -64,7 +64,7 @@ def main(config: DictConfig):
 
     logger.info(f"Using pre-trained checkpoint.")
     # load the model 
-    rayltmodule             = raygun_2_2mil_800M(return_lightning_module=True)
+    rayltmodule             = raygun_4_4mil_800M(return_lightning_module=True)
     
     if "checkpoint" in config and config["checkpoint"] is not None:
         ckptpath   = Path(config["checkpoint"])
@@ -76,6 +76,13 @@ def main(config: DictConfig):
     rayltmodule.lr          = config["lr"]
     rayltmodule.finetune    = False
     rayltmodule.epoch       = 0
+    
+    ## fixed the batching problem 
+    if "fix_batching_esmdecoder" in config and config["fix_batching_esmdecoder"]:
+        rayltmodule.model.esmdecoder.fixed_batching=True
+    else:
+        rayltmodule.model.esmdecoder.fixed_batching=False
+        
     
     ## train and validation loaders
     traindata = RaygunData(fastafile = config["trainfasta"],

--- a/raygun/modelv2/ltraygun.py
+++ b/raygun/modelv2/ltraygun.py
@@ -79,8 +79,7 @@ class RaygunLightning(L.LightningModule):
             mode='min',
             factor=0.5,
             patience=5,
-            min_lr=1e-6,
-            verbose=True
+            min_lr=1e-6
         )
         # Return optimizer and scheduler
         return {

--- a/raygun/modelv2/raygun.py
+++ b/raygun/modelv2/raygun.py
@@ -125,7 +125,8 @@ class Raygun(nn.Module):
                  numencoders = 10, numdecoders = 10,
                  dropout = 0.1,
                  reduction = 50, activation = "gelu",
-                 esmdecodertotokenfile = None):
+                 esmdecodertotokenfile = None, 
+                 fixed_esm_batching=False):
         super(Raygun, self).__init__()
         self.encoder = RaygunEncoder(dim     = dim, 
                                 reduction    = reduction, 
@@ -142,7 +143,8 @@ class Raygun(nn.Module):
                                  activation  = activation)
 
         self.esmdecoder = DecoderBlock(dim = dim, 
-                                      nhead = 20)
+                                      nhead = 20, 
+                                      fixed_batching=fixed_esm_batching)
         if esmdecodertotokenfile is not None:
             checkpoint = torch.load(esmdecodertotokenfile)
             self.esmdecoder.load_state_dict(checkpoint["model_state"])

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="raygun",
-    version="0.2.1",
+    version="0.2.3",
     author="Kapil Devkota",
     author_email="kapil.devkota@duke.edu",
     description="Protein Redesign using Raygun",


### PR DESCRIPTION
The previous `raygun.modelv2.esmdecoder.DecoderModel` had an bug: this class internally usesdESM2 TransformerLayer---which accepts tensors with dimensions `[seq, batch, dim]`---to convert the ESM-2 embeddings back to logits. 

The previous implementation was however trained by passing PLM embeddings in the form `[batch, seq, dim]` instead. Fortunately, after training, the output model still had a very high accuracy (>0.99 sequence identity). This "buggy" implementation can still be recreated by setting `fixed_batching=False` in the DecoderModel. 

The updated DecoderModel, where the shape of the input embedding is faithful to the TransformerLayer implementation, can be obtained by setting `fixed_batching=True`. Furthermore, if users want to train the new model using this "fixed" DecoderModel, they can add the `fix_batching_esmdecoder` argument to `train.py`'s YAML configuration file.